### PR TITLE
Do not crash on empty history range or error

### DIFF
--- a/lib/node.js
+++ b/lib/node.js
@@ -586,7 +586,7 @@ Node.prototype.getHistory = function (range)
 	var self = this;
 
 	var history = [];
-	var interv = {};
+	var interv = [];
 
 	console.time('=H=', 'his', 'Got history in');
 
@@ -607,7 +607,7 @@ Node.prototype.getHistory = function (range)
 		if (err) {
 			console.error('his', 'history fetch failed:', err);
 
-			results = false;
+			results = [];
 		}
 		else
 		{


### PR DESCRIPTION
eth-netstats passes `false` as the range, in which case the result of
the operation ends up as `{}` and `results.reverse()` crashes as it is
not defined. Switch to an `[]` in that case, and do the same in case of
error as well.